### PR TITLE
Add the answer relevance evaluation 

### DIFF
--- a/Evaluation/eval_answer_relevance.py
+++ b/Evaluation/eval_answer_relevance.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+Automated Evaluation System for Isschat
+Evaluates chatbot responses against expected behaviors using LLM as judge
+"""
+
+import json
+import logging
+import time
+import sys
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional
+from dataclasses import dataclass
+
+# Add the src directory to Python path to import Isschat modules
+sys.path.append(str(Path(__file__).parent.parent / "src"))
+
+from help_desk import HelpDesk
+from config import get_config
+from langchain_openai import ChatOpenAI
+from langchain_core.utils.utils import convert_to_secret_str
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    handlers=[logging.FileHandler("evaluation.log"), logging.StreamHandler()],
+)
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EvaluationResult:
+    """Data class to hold evaluation results"""
+
+    question: str
+    isschat_response: str
+    expected_answer: str
+    evaluation: str
+    response_time: float
+    error: str = ""
+
+
+class IsschatEvaluator:
+    """Main evaluator class for Isschat responses"""
+
+    def __init__(self, dataset_path: str = "question_dataset.json"):
+        """Initialize the evaluator with dataset path"""
+        self.dataset_path = Path(__file__).parent / dataset_path
+        self.results: List[EvaluationResult] = []
+
+        # Initialize Isschat
+        logger.info("Initializing Isschat...")
+        try:
+            self.isschat = HelpDesk(new_db=False)  # Use existing DB for faster startup
+            logger.info("Isschat initialized successfully")
+        except Exception as e:
+            logger.error(f"Failed to initialize Isschat: {e}")
+            raise
+
+        # Initialize LLM judge
+        logger.info("Initializing LLM judge...")
+        try:
+            self.judge_llm = self._initialize_judge_llm()
+            logger.info("LLM judge initialized successfully")
+        except Exception as e:
+            logger.error(f"Failed to initialize LLM judge: {e}")
+            raise
+
+    def _initialize_judge_llm(self) -> ChatOpenAI:
+        """Initialize the LLM that will act as judge"""
+        config = get_config()
+        api_key = convert_to_secret_str(config.openrouter_api_key)
+
+        if not api_key:
+            raise ValueError("OPENROUTER_API_KEY not found in configuration")
+
+        # Use a more capable model for evaluation
+        judge_llm = ChatOpenAI(
+            model_name="anthropic/claude-3.5-sonnet",  # More capable model for evaluation
+            temperature=0.0,  # Deterministic evaluation
+            max_tokens=100,  # Short responses for binary evaluation
+            openai_api_key=api_key,
+            openai_api_base="https://openrouter.ai/api/v1",
+        )
+        return judge_llm
+
+    def load_dataset(self) -> List[Dict]:
+        """Load the question dataset from JSON file"""
+        try:
+            with open(self.dataset_path, "r", encoding="utf-8") as f:
+                dataset = json.load(f)
+            logger.info(f"Loaded {len(dataset)} questions from {self.dataset_path}")
+            return dataset
+        except FileNotFoundError:
+            logger.error(f"Dataset file not found: {self.dataset_path}")
+            raise
+        except json.JSONDecodeError as e:
+            logger.error(f"Invalid JSON in dataset file: {e}")
+            raise
+
+    def query_isschat(self, question: str) -> Tuple[str, float]:
+        """Query Isschat and measure response time"""
+        start_time = time.time()
+        try:
+            # Use verbose=False to reduce log noise during evaluation
+            response, sources = self.isschat.retrieval_qa_inference(question, verbose=False)
+            response_time = time.time() - start_time
+
+            # Combine response and sources for complete answer
+            full_response = f"{response}\n\nSources: {sources}" if sources else response
+
+            logger.info(f"Isschat responded in {response_time:.2f}s")
+            return full_response, response_time
+
+        except Exception as e:
+            response_time = time.time() - start_time
+            logger.error(f"Error querying Isschat: {e}")
+            return f"ERROR: {str(e)}", response_time
+
+    def evaluate_response(self, question: str, isschat_response: str, expected_answer: str) -> str:
+        """Use LLM judge to evaluate the response"""
+
+        # Create evaluation prompt
+        evaluation_prompt = f"""Tu es un évaluateur expert pour un chatbot d'entreprise nommé Isschat.
+
+QUESTION POSÉE: {question}
+
+RÉPONSE D'ISSCHAT: {isschat_response}
+
+COMPORTEMENT ATTENDU: {expected_answer}
+
+INSTRUCTIONS:
+- Évalue si la réponse d'Isschat correspond au comportement attendu
+- Considère le contexte d'un chatbot d'entreprise basé sur Confluence
+- Réponds UNIQUEMENT par "rather good" ou "rather bad"
+- "rather good" = la réponse respecte globalement le comportement attendu
+- "rather bad" = la réponse ne respecte pas le comportement attendu
+
+ÉVALUATION:"""
+
+        try:
+            # Get evaluation from judge LLM
+            evaluation = self.judge_llm.invoke(evaluation_prompt).content.strip().lower()
+
+            # Normalize the response
+            if "rather good" in evaluation:
+                return "rather good"
+            elif "rather bad" in evaluation:
+                return "rather bad"
+            else:
+                logger.warning(f"Unexpected evaluation response: {evaluation}")
+                return "rather bad"  # Default to bad if unclear
+
+        except Exception as e:
+            logger.error(f"Error during evaluation: {e}")
+            return "rather bad"  # Default to bad on error
+
+    def run_evaluation(self) -> List[EvaluationResult]:
+        """Run the complete evaluation process"""
+        logger.info("Starting evaluation process...")
+
+        # Load dataset
+        dataset = self.load_dataset()
+
+        # Process each question
+        for i, item in enumerate(dataset, 1):
+            question = item["question"]
+            expected_answer = item["expected_answer"]
+
+            logger.info(f"Processing question {i}/{len(dataset)}: {question[:50]}...")
+
+            # Query Isschat
+            isschat_response, response_time = self.query_isschat(question)
+
+            # Skip evaluation if there was an error
+            if isschat_response.startswith("ERROR:"):
+                evaluation = "rather bad"
+                error = isschat_response
+            else:
+                # Evaluate response
+                evaluation = self.evaluate_response(question, isschat_response, expected_answer)
+                error = ""
+
+            # Store result
+            result = EvaluationResult(
+                question=question,
+                isschat_response=isschat_response,
+                expected_answer=expected_answer,
+                evaluation=evaluation,
+                response_time=response_time,
+                error=error,
+            )
+            self.results.append(result)
+
+            logger.info(f"Question {i} evaluated as: {evaluation}")
+
+            # Add small delay to avoid overwhelming the system
+            time.sleep(1)
+
+        logger.info("Evaluation process completed")
+        return self.results
+
+    def save_results(self, output_path: Optional[str] = None) -> None:
+        """Save evaluation results back to JSON file"""
+        if output_path is None:
+            output_path = self.dataset_path
+
+        # Convert results to the expected JSON format
+        output_data = []
+        for result in self.results:
+            output_data.append(
+                {
+                    "question": result.question,
+                    "isschat_response": result.isschat_response,
+                    "expected_answer": result.expected_answer,
+                    "evaluation": result.evaluation,
+                }
+            )
+
+        try:
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump(output_data, f, ensure_ascii=False, indent=2)
+            logger.info(f"Results saved to {output_path}")
+        except Exception as e:
+            logger.error(f"Error saving results: {e}")
+            raise
+
+    def print_summary(self) -> None:
+        """Print evaluation summary"""
+        if not self.results:
+            logger.warning("No results to summarize")
+            return
+
+        total_questions = len(self.results)
+        good_responses = sum(1 for r in self.results if r.evaluation == "rather good")
+        bad_responses = sum(1 for r in self.results if r.evaluation == "rather bad")
+        avg_response_time = sum(r.response_time for r in self.results) / total_questions
+        errors = sum(1 for r in self.results if r.error)
+
+        print("\n" + "=" * 60)
+        print("EVALUATION SUMMARY")
+        print("=" * 60)
+        print(f"Total Questions: {total_questions}")
+        print(f"Rather Good: {good_responses} ({good_responses / total_questions * 100:.1f}%)")
+        print(f"Rather Bad: {bad_responses} ({bad_responses / total_questions * 100:.1f}%)")
+        print(f"Errors: {errors}")
+        print(f"Average Response Time: {avg_response_time:.2f}s")
+        print("=" * 60)
+
+        # Print detailed results
+        print("\nDETAILED RESULTS:")
+        print("-" * 60)
+        for i, result in enumerate(self.results, 1):
+            status_icon = "✅" if result.evaluation == "rather good" else "❌"
+            print(f"{i:2d}. {status_icon} {result.evaluation.upper()}")
+            print(f"    Q: {result.question[:80]}...")
+            if result.error:
+                print(f"    ERROR: {result.error}")
+            print(f"    Time: {result.response_time:.2f}s")
+            print()
+
+
+def main():
+    """Main execution function"""
+    try:
+        # Initialize evaluator
+        evaluator = IsschatEvaluator()
+
+        # Run evaluation
+        evaluator.run_evaluation()
+
+        # Save results
+        evaluator.save_results()
+
+        # Print summary
+        evaluator.print_summary()
+
+        logger.info("Evaluation completed successfully!")
+
+    except KeyboardInterrupt:
+        logger.info("Evaluation interrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        logger.error(f"Evaluation failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Evaluation/eval_answer_relevance.py
+++ b/Evaluation/eval_answer_relevance.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """
-Automated Evaluation System for Isschat
-Evaluates chatbot responses against expected behaviors using LLM as judge
+Automated Evaluation System for Isschat - Concise OOP Implementation
 """
 
 import json
@@ -9,10 +8,9 @@ import logging
 import time
 import sys
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional
 from dataclasses import dataclass
 
-# Add the src directory to Python path to import Isschat modules
 sys.path.append(str(Path(__file__).parent.parent / "src"))
 
 from help_desk import HelpDesk
@@ -20,18 +18,13 @@ from config import get_config
 from langchain_openai import ChatOpenAI
 from langchain_core.utils.utils import convert_to_secret_str
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[logging.FileHandler("evaluation.log"), logging.StreamHandler()],
-)
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
 @dataclass
 class EvaluationResult:
-    """Data class to hold evaluation results"""
+    """Evaluation result data structure"""
 
     question: str
     isschat_response: str
@@ -40,246 +33,209 @@ class EvaluationResult:
     response_time: float
     error: str = ""
 
+    @property
+    def is_good(self) -> bool:
+        return self.evaluation == "rather good"
 
-class IsschatEvaluator:
-    """Main evaluator class for Isschat responses"""
+    def to_dict(self) -> Dict:
+        return {
+            "question": self.question,
+            "isschat_response": self.isschat_response,
+            "expected_answer": self.expected_answer,
+            "evaluation": self.evaluation,
+        }
 
-    def __init__(self, dataset_path: str = "question_dataset.json"):
-        """Initialize the evaluator with dataset path"""
-        self.dataset_path = Path(__file__).parent / dataset_path
-        self.results: List[EvaluationResult] = []
 
-        # Initialize Isschat
-        logger.info("Initializing Isschat...")
-        try:
-            self.isschat = HelpDesk(new_db=False)  # Use existing DB for faster startup
-            logger.info("Isschat initialized successfully")
-        except Exception as e:
-            logger.error(f"Failed to initialize Isschat: {e}")
-            raise
+class LLMJudge:
+    """LLM-based evaluation judge"""
 
-        # Initialize LLM judge
-        logger.info("Initializing LLM judge...")
-        try:
-            self.judge_llm = self._initialize_judge_llm()
-            logger.info("LLM judge initialized successfully")
-        except Exception as e:
-            logger.error(f"Failed to initialize LLM judge: {e}")
-            raise
-
-    def _initialize_judge_llm(self) -> ChatOpenAI:
-        """Initialize the LLM that will act as judge"""
-        config = get_config()
-        api_key = convert_to_secret_str(config.openrouter_api_key)
-
-        if not api_key:
-            raise ValueError("OPENROUTER_API_KEY not found in configuration")
-
-        # Use a more capable model for evaluation
-        judge_llm = ChatOpenAI(
-            model_name="anthropic/claude-3.5-sonnet",  # More capable model for evaluation
-            temperature=0.0,  # Deterministic evaluation
-            max_tokens=100,  # Short responses for binary evaluation
-            openai_api_key=api_key,
-            openai_api_base="https://openrouter.ai/api/v1",
-        )
-        return judge_llm
-
-    def load_dataset(self) -> List[Dict]:
-        """Load the question dataset from JSON file"""
-        try:
-            with open(self.dataset_path, "r", encoding="utf-8") as f:
-                dataset = json.load(f)
-            logger.info(f"Loaded {len(dataset)} questions from {self.dataset_path}")
-            return dataset
-        except FileNotFoundError:
-            logger.error(f"Dataset file not found: {self.dataset_path}")
-            raise
-        except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON in dataset file: {e}")
-            raise
-
-    def query_isschat(self, question: str) -> Tuple[str, float]:
-        """Query Isschat and measure response time"""
-        start_time = time.time()
-        try:
-            # Use verbose=False to reduce log noise during evaluation
-            response, sources = self.isschat.retrieval_qa_inference(question, verbose=False)
-            response_time = time.time() - start_time
-
-            # Combine response and sources for complete answer
-            full_response = f"{response}\n\nSources: {sources}" if sources else response
-
-            logger.info(f"Isschat responded in {response_time:.2f}s")
-            return full_response, response_time
-
-        except Exception as e:
-            response_time = time.time() - start_time
-            logger.error(f"Error querying Isschat: {e}")
-            return f"ERROR: {str(e)}", response_time
-
-    def evaluate_response(self, question: str, isschat_response: str, expected_answer: str) -> str:
-        """Use LLM judge to evaluate the response"""
-
-        # Create evaluation prompt
-        evaluation_prompt = f"""Tu es un évaluateur expert pour un chatbot d'entreprise nommé Isschat.
+    EVALUATION_PROMPT = """Tu es un évaluateur expert pour un chatbot d'entreprise nommé Isschat.
 
 QUESTION POSÉE: {question}
-
-RÉPONSE D'ISSCHAT: {isschat_response}
-
-COMPORTEMENT ATTENDU: {expected_answer}
+RÉPONSE D'ISSCHAT: {response}
+COMPORTEMENT ATTENDU: {expected}
 
 INSTRUCTIONS:
 - Évalue si la réponse d'Isschat correspond au comportement attendu
-- Considère le contexte d'un chatbot d'entreprise basé sur Confluence
 - Réponds UNIQUEMENT par "rather good" ou "rather bad"
-- "rather good" = la réponse respecte globalement le comportement attendu
-- "rather bad" = la réponse ne respecte pas le comportement attendu
 
 ÉVALUATION:"""
 
+    def __init__(self):
+        config = get_config()
+        api_key = convert_to_secret_str(config.openrouter_api_key)
+        if not api_key:
+            raise ValueError("OPENROUTER_API_KEY not found")
+
+        self.llm = ChatOpenAI(
+            model_name="anthropic/claude-3.5-sonnet",
+            temperature=0.0,
+            max_tokens=100,
+            openai_api_key=api_key,
+            openai_api_base="https://openrouter.ai/api/v1",
+        )
+
+    def evaluate(self, question: str, response: str, expected: str) -> str:
+        """Evaluate response quality"""
         try:
-            # Get evaluation from judge LLM
-            evaluation = self.judge_llm.invoke(evaluation_prompt).content.strip().lower()
-
-            # Normalize the response
-            if "rather good" in evaluation:
-                return "rather good"
-            elif "rather bad" in evaluation:
-                return "rather bad"
-            else:
-                logger.warning(f"Unexpected evaluation response: {evaluation}")
-                return "rather bad"  # Default to bad if unclear
-
+            prompt = self.EVALUATION_PROMPT.format(question=question, response=response, expected=expected)
+            result = self.llm.invoke(prompt).content.strip().lower()
+            return "rather good" if "rather good" in result else "rather bad"
         except Exception as e:
-            logger.error(f"Error during evaluation: {e}")
-            return "rather bad"  # Default to bad on error
+            logger.error(f"Evaluation error: {e}")
+            return "rather bad"
 
-    def run_evaluation(self) -> List[EvaluationResult]:
-        """Run the complete evaluation process"""
-        logger.info("Starting evaluation process...")
 
-        # Load dataset
-        dataset = self.load_dataset()
+class IsschatQuerier:
+    """Handles Isschat queries and timing"""
 
-        # Process each question
-        for i, item in enumerate(dataset, 1):
-            question = item["question"]
-            expected_answer = item["expected_answer"]
+    def __init__(self):
+        self.isschat = HelpDesk(new_db=False)
+        logger.info("Isschat initialized")
 
-            logger.info(f"Processing question {i}/{len(dataset)}: {question[:50]}...")
-
-            # Query Isschat
-            isschat_response, response_time = self.query_isschat(question)
-
-            # Skip evaluation if there was an error
-            if isschat_response.startswith("ERROR:"):
-                evaluation = "rather bad"
-                error = isschat_response
-            else:
-                # Evaluate response
-                evaluation = self.evaluate_response(question, isschat_response, expected_answer)
-                error = ""
-
-            # Store result
-            result = EvaluationResult(
-                question=question,
-                isschat_response=isschat_response,
-                expected_answer=expected_answer,
-                evaluation=evaluation,
-                response_time=response_time,
-                error=error,
-            )
-            self.results.append(result)
-
-            logger.info(f"Question {i} evaluated as: {evaluation}")
-
-            # Add small delay to avoid overwhelming the system
-            time.sleep(1)
-
-        logger.info("Evaluation process completed")
-        return self.results
-
-    def save_results(self, output_path: Optional[str] = None) -> None:
-        """Save evaluation results back to JSON file"""
-        if output_path is None:
-            output_path = self.dataset_path
-
-        # Convert results to the expected JSON format
-        output_data = []
-        for result in self.results:
-            output_data.append(
-                {
-                    "question": result.question,
-                    "isschat_response": result.isschat_response,
-                    "expected_answer": result.expected_answer,
-                    "evaluation": result.evaluation,
-                }
-            )
-
+    def query(self, question: str) -> tuple[str, float]:
+        """Query Isschat with timing"""
+        start_time = time.time()
         try:
-            with open(output_path, "w", encoding="utf-8") as f:
-                json.dump(output_data, f, ensure_ascii=False, indent=2)
-            logger.info(f"Results saved to {output_path}")
+            response, sources = self.isschat.retrieval_qa_inference(question, verbose=False)
+            response_time = time.time() - start_time
+            full_response = f"{response}\n\nSources: {sources}" if sources else response
+            return full_response, response_time
         except Exception as e:
-            logger.error(f"Error saving results: {e}")
-            raise
+            response_time = time.time() - start_time
+            return f"ERROR: {str(e)}", response_time
+
+
+class EvaluationSummary:
+    """Handles evaluation summary and reporting"""
+
+    def __init__(self, results: List[EvaluationResult]):
+        self.results = results
 
     def print_summary(self) -> None:
-        """Print evaluation summary"""
+        """Print comprehensive evaluation summary"""
         if not self.results:
             logger.warning("No results to summarize")
             return
 
-        total_questions = len(self.results)
-        good_responses = sum(1 for r in self.results if r.evaluation == "rather good")
-        bad_responses = sum(1 for r in self.results if r.evaluation == "rather bad")
-        avg_response_time = sum(r.response_time for r in self.results) / total_questions
+        total = len(self.results)
+        good = sum(1 for r in self.results if r.is_good)
+        bad = total - good
+        avg_time = sum(r.response_time for r in self.results) / total
         errors = sum(1 for r in self.results if r.error)
 
-        print("\n" + "=" * 60)
+        print(f"\n{'=' * 60}")
         print("EVALUATION SUMMARY")
-        print("=" * 60)
-        print(f"Total Questions: {total_questions}")
-        print(f"Rather Good: {good_responses} ({good_responses / total_questions * 100:.1f}%)")
-        print(f"Rather Bad: {bad_responses} ({bad_responses / total_questions * 100:.1f}%)")
+        print(f"{'=' * 60}")
+        print(f"Total Questions: {total}")
+        print(f"Rather Good: {good} ({good / total * 100:.1f}%)")
+        print(f"Rather Bad: {bad} ({bad / total * 100:.1f}%)")
         print(f"Errors: {errors}")
-        print(f"Average Response Time: {avg_response_time:.2f}s")
-        print("=" * 60)
+        print(f"Average Response Time: {avg_time:.2f}s")
+        print(f"{'=' * 60}")
 
-        # Print detailed results
         print("\nDETAILED RESULTS:")
-        print("-" * 60)
+        print(f"{'-' * 60}")
         for i, result in enumerate(self.results, 1):
-            status_icon = "✅" if result.evaluation == "rather good" else "❌"
-            print(f"{i:2d}. {status_icon} {result.evaluation.upper()}")
+            icon = "✅" if result.is_good else "❌"
+            print(f"{i:2d}. {icon} {result.evaluation.upper()}")
             print(f"    Q: {result.question[:80]}...")
             if result.error:
                 print(f"    ERROR: {result.error}")
-            print(f"    Time: {result.response_time:.2f}s")
-            print()
+            print(f"    Time: {result.response_time:.2f}s\n")
+
+
+class IsschatEvaluator:
+    """Main evaluation orchestrator"""
+
+    def __init__(self, dataset_path: str = "question_dataset.json"):
+        self.dataset_path = Path(__file__).parent / dataset_path
+        self.results: List[EvaluationResult] = []
+
+        # Initialize components
+        self.querier = IsschatQuerier()
+        self.judge = LLMJudge()
+        logger.info("Evaluator initialized")
+
+    def load_dataset(self) -> List[Dict]:
+        """Load evaluation dataset"""
+        try:
+            with open(self.dataset_path, "r", encoding="utf-8") as f:
+                dataset = json.load(f)
+            logger.info(f"Loaded {len(dataset)} questions")
+            return dataset
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            logger.error(f"Dataset loading failed: {e}")
+            raise
+
+    def evaluate_single(self, item: Dict, index: int, total: int) -> EvaluationResult:
+        """Evaluate a single question"""
+        question = item["question"]
+        expected = item["expected_answer"]
+
+        logger.info(f"Processing {index}/{total}: {question[:50]}...")
+
+        # Query and evaluate
+        response, response_time = self.querier.query(question)
+
+        if response.startswith("ERROR:"):
+            evaluation, error = "rather bad", response
+        else:
+            evaluation = self.judge.evaluate(question, response, expected)
+            error = ""
+
+        result = EvaluationResult(
+            question=question,
+            isschat_response=response,
+            expected_answer=expected,
+            evaluation=evaluation,
+            response_time=response_time,
+            error=error,
+        )
+
+        logger.info(f"Result: {evaluation}")
+        return result
+
+    def run_evaluation(self) -> List[EvaluationResult]:
+        """Execute complete evaluation process"""
+        logger.info("Starting evaluation...")
+        dataset = self.load_dataset()
+
+        for i, item in enumerate(dataset, 1):
+            result = self.evaluate_single(item, i, len(dataset))
+            self.results.append(result)
+            time.sleep(1)  # Rate limiting
+
+        logger.info("Evaluation completed")
+        return self.results
+
+    def save_results(self, output_path: Optional[str] = None) -> None:
+        """Save results to JSON"""
+        path = output_path or self.dataset_path
+        try:
+            data = [result.to_dict() for result in self.results]
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            logger.info(f"Results saved to {path}")
+        except Exception as e:
+            logger.error(f"Save failed: {e}")
+            raise
+
+    def get_summary(self) -> EvaluationSummary:
+        """Get evaluation summary"""
+        return EvaluationSummary(self.results)
 
 
 def main():
-    """Main execution function"""
+    """Main execution"""
     try:
-        # Initialize evaluator
         evaluator = IsschatEvaluator()
-
-        # Run evaluation
         evaluator.run_evaluation()
-
-        # Save results
         evaluator.save_results()
-
-        # Print summary
-        evaluator.print_summary()
-
+        evaluator.get_summary().print_summary()
         logger.info("Evaluation completed successfully!")
-
     except KeyboardInterrupt:
-        logger.info("Evaluation interrupted by user")
+        logger.info("Interrupted by user")
         sys.exit(1)
     except Exception as e:
         logger.error(f"Evaluation failed: {e}")

--- a/Evaluation/question_dataset.json
+++ b/Evaluation/question_dataset.json
@@ -7,79 +7,79 @@
   },
   {
     "question": "Parle moi du daily du 35 mai 2018 ?",
-    "isschat_response": "Bonjour ! Malheureusement, je n'ai pas d'informations concernant un \"daily du 35 mai 2018\" dans la documentation disponible. Je vous suggère de vérifier directement dans vos archives Confluence ou de consulter vos notes internes pour cette date spécifique. Si vous avez besoin d'aide pour configurer ou accéder à votre espace Confluence, je suis là pour vous guider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Environment Variables](dummy_doc_3)  \n- [Welcome](dummy_doc_1)",
+    "isschat_response": "Bonjour ! Malheureusement, je ne dispose pas d’informations concernant le daily du 35 mai 2018 dans la documentation accessible. Je vous suggère de vérifier directement dans vos archives Confluence ou de contacter un collègue qui pourrait avoir assisté à cette réunion. Si vous avez besoin d’aide pour configurer ou accéder à votre espace Confluence, je suis là pour vous guider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Environment Variables](dummy_doc_3)  \n- [Welcome](dummy_doc_1)",
     "expected_answer": "Doit détecter que la date est invalide (35 mai n'existe pas) et l’indiquer clairement.",
     "evaluation": "rather bad"
   },
   {
     "question": "Connais tu Emin Lambropoulos ?",
-    "isschat_response": "Bonjour ! Je n’ai pas d’informations concernant Emin Lambropoulos dans la documentation Confluence à ma disposition. Je vous suggère de vérifier dans d’autres sources internes ou de contacter directement votre réseau professionnel pour en savoir plus. Si vous avez besoin d’aide pour autre chose liée à Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Environment Variables](dummy_doc_3)",
+    "isschat_response": "Bonjour ! Je n'ai pas d'informations concernant Emin Lambropoulos dans la documentation Confluence à ma disposition. Je vous suggère de vérifier dans d'autres sources internes ou de contacter directement votre équipe pour en savoir plus. Si vous avez d'autres questions sur la configuration ou l'utilisation de Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Environment Variables](dummy_doc_3)",
     "expected_answer": "Doit indiquer ne pas connaître cette personne. Peut mentionner qu’il connaît Nicolas Lambropoulos et Emin Calyaka.",
     "evaluation": "rather good"
   },
   {
     "question": "Connais tu Johan Jublanc ?",
-    "isschat_response": "Bonjour ! Je n'ai pas d'informations concernant Johan Jublanc dans la documentation Confluence dont je dispose actuellement. Je vous suggère de vérifier directement dans votre base de données interne ou de consulter vos collègues qui pourraient en savoir plus. Si vous avez d'autres questions sur la configuration ou l'utilisation de Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
+    "isschat_response": "Bonjour ! Je n'ai pas d'informations concernant Johan Jublanc dans la documentation Confluence à ma disposition. Je vous suggère de vérifier directement dans votre base de données interne ou de consulter vos collègues qui pourraient en savoir plus. Si vous avez d'autres questions sur la documentation, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
     "expected_answer": "Doit fournir des informations sur les contributions de Johan Jublanc disponibles sur Confluence.",
     "evaluation": "rather good"
   },
   {
     "question": "A quoi sert l'eau ?",
-    "isschat_response": "Bonjour ! Votre question sur l'eau ne concerne pas directement la documentation Confluence dont je dispose. Cependant, pour répondre brièvement, l'eau est essentielle à la vie : elle hydrate, permet les réactions chimiques dans les organismes, et est indispensable à de nombreux processus naturels et industriels. \n\nSi vous avez des questions spécifiques sur la documentation Confluence ou son utilisation, je vous invite à me les poser, je serai ravi de vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Environment Variables](dummy_doc_3)",
+    "isschat_response": "Bonjour ! Votre question sur l'eau ne concerne pas directement la documentation Confluence dont je dispose. Cependant, je peux vous dire que, de manière générale, l'eau est essentielle à la vie, elle sert à l'hydratation, à la cuisson, au nettoyage, et bien plus encore. Si vous cherchez des informations spécifiques liées à Confluence ou à la configuration technique, je vous invite à me poser une autre question. Je suis là pour vous aider avec tout ce qui touche à Confluence !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Environment Variables](dummy_doc_3)",
     "expected_answer": "Doit rediriger vers le contexte entreprise ou indiquer que ce n’est pas dans le périmètre d’Isschat.",
     "evaluation": "rather good"
   },
   {
     "question": "Sur quelles missions Vincent Fraillon travaille-t-il actuellement ?",
-    "isschat_response": "Bonjour ! Malheureusement, je n’ai pas d’informations concernant les missions actuelles de Vincent Fraillon dans la documentation disponible. Je vous suggère de consulter directement les ressources internes de votre équipe ou de contacter Vincent ou son manager pour obtenir ces détails. Si vous avez d’autres questions sur la configuration ou l’utilisation de Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Welcome](dummy_doc_1)",
+    "isschat_response": "Bonjour ! Malheureusement, je n’ai pas d’informations concernant les missions actuelles de Vincent Fraillon dans les documents disponibles. Je vous suggère de consulter directement les ressources internes de votre équipe ou de contacter Vincent ou son manager pour obtenir ces détails. Si vous avez d’autres questions sur la documentation Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Welcome](dummy_doc_1)",
     "expected_answer": "Doit donner des missions actuelles de Vincent Fraillon si disponibles.",
     "evaluation": "rather good"
   },
   {
     "question": "Je suis stagiaire chez Isskar, quelles sont mes avantages ?",
-    "isschat_response": "Bonjour ! Malheureusement, je n’ai pas d’informations spécifiques concernant les avantages pour les stagiaires chez Isskar dans la documentation disponible. Je vous suggère de consulter directement votre responsable RH ou votre tuteur de stage pour obtenir ces détails. Si vous avez d’autres questions sur la configuration ou l’utilisation de Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
+    "isschat_response": "Bonjour ! Malheureusement, dans la documentation Confluence dont je dispose actuellement, je ne trouve pas d’informations spécifiques concernant les avantages pour les stagiaires chez Isskar. \n\nJe vous suggère de consulter directement votre responsable RH ou votre tuteur de stage, ou bien de vérifier dans l’espace Confluence interne de votre entreprise si une page dédiée aux avantages des stagiaires existe. Vous pourriez aussi demander s’il y a un guide ou une FAQ interne qui détaille ces informations.\n\nN’hésitez pas si vous avez d’autres questions !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
     "expected_answer": "Doit demander plus de précisions ou fournir une liste des avantages si disponibles.",
     "evaluation": "rather good"
   },
   {
     "question": "Quel est le lien entre Isskar et le nœud Gordien ?",
-    "isschat_response": "Bonjour ! D'après les documents dont je dispose, je n'ai malheureusement pas d'information concernant un lien entre Isskar et le nœud Gordien. Je vous suggère de consulter directement la documentation Confluence ou de poser la question à un expert du domaine concerné pour obtenir des détails précis. Si vous avez d'autres questions ou besoin d'aide sur la configuration ou l'utilisation de Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
+    "isschat_response": "Bonjour ! D'après les documents dont je dispose, je n'ai malheureusement pas d'information concernant un lien entre Isskar et le nœud Gordien. Je vous suggère de consulter directement la documentation Confluence ou de vérifier auprès de vos collègues qui pourraient avoir des connaissances spécifiques sur ce sujet. Si vous avez d'autres questions ou besoin d'aide pour trouver des informations dans la documentation, n'hésitez pas à me demander !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
     "expected_answer": "Doit retrouver la page parlant du nœud Gordien et expliquer le lien.",
-    "evaluation": "rather bad"
+    "evaluation": "rather good"
   },
   {
     "question": "Qui lead le projet CIBTP ?",
-    "isschat_response": "Bonjour ! D'après les extraits de documents dont je dispose, je n'ai malheureusement pas d'information concernant la personne qui lead le projet CIBTP. Je vous suggère de consulter directement les pages spécifiques du projet dans Confluence ou de contacter votre responsable d'équipe pour obtenir cette information. Si vous avez d'autres questions, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
+    "isschat_response": "Bonjour ! D'après les extraits dont je dispose, je n'ai pas d'information concernant la personne qui lead le projet CIBTP. Je vous suggère de consulter directement la documentation Confluence liée à ce projet ou de contacter un collègue qui pourrait avoir cette information. Si vous avez besoin d'aide pour naviguer dans Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
     "expected_answer": "Doit identifier et nommer le ou la responsable du projet CIBTP.",
     "evaluation": "rather good"
   },
   {
     "question": "Décris moi le brief qui a été fait pour Adam ?",
-    "isschat_response": "Bonjour ! D'après les documents dont je dispose, je n'ai malheureusement pas d'informations spécifiques concernant un brief fait pour Adam. Je vous suggère de vérifier directement dans la documentation Confluence ou de consulter les notes de réunion associées à ce projet. Si vous avez d'autres questions ou besoin d'aide pour trouver des informations précises, n'hésitez pas à me demander !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Welcome](dummy_doc_1)",
+    "isschat_response": "Bonjour ! D'après les documents dont je dispose, il n'y a pas d'information spécifique concernant un brief fait pour Adam. Je vous suggère de vérifier directement dans vos pages Confluence ou de préciser davantage le contexte ou le projet lié à ce brief. Si vous avez d'autres questions ou besoin d'aide pour naviguer dans la documentation, n'hésitez pas à me demander !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Welcome](dummy_doc_1)",
     "expected_answer": "Doit refuser l’accès à cette information si elle est confidentielle.",
     "evaluation": "rather good"
   },
   {
     "question": "Tell me more about Cedrus project.",
-    "isschat_response": "Bonjour ! Malheureusement, je n'ai pas d'informations spécifiques concernant le projet Cedrus dans les documents disponibles. Je vous suggère de vérifier directement dans votre espace Confluence ou de contacter un collègue qui pourrait avoir accès à ces données. Si vous souhaitez, je peux aussi vous aider à formuler une recherche plus précise dans la documentation. N’hésitez pas à me demander !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
+    "isschat_response": "Bonjour ! Malheureusement, je n'ai pas d'informations spécifiques concernant le projet Cedrus dans la documentation disponible. Je vous suggère de vérifier directement dans votre espace Confluence ou de contacter un collègue qui pourrait avoir plus de détails. Si vous avez besoin d'aide pour configurer ou accéder à Confluence, je suis là pour vous accompagner !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
     "expected_answer": "Doit répondre en français, même si la question est en anglais.",
     "evaluation": "rather good"
   },
   {
     "question": "Résume moi les articles de la veille technique 2024-12-16",
-    "isschat_response": "Bonjour ! Malheureusement, je ne dispose pas des articles de la veille technique du 16 décembre 2024 dans les documents accessibles actuellement. Je vous suggère de vérifier directement dans votre espace Confluence ou de consulter la section dédiée aux veilles techniques pour cette date précise. Si vous avez besoin d’aide pour configurer votre connexion Confluence afin d’accéder aux données réelles, je peux vous guider avec plaisir !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
+    "isschat_response": "Bonjour ! Malheureusement, je n’ai pas accès aux articles de la veille technique du 16 décembre 2024 dans les documents disponibles. Je vous suggère de vérifier directement dans votre espace Confluence ou de consulter la base de données officielle pour cette date précise. Si vous avez d’autres questions ou besoin d’aide pour configurer votre accès à Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
     "expected_answer": "Doit retrouver la veille technique de cette date et la résumer clairement.",
     "evaluation": "rather good"
   },
   {
     "question": "Quelle est la stratégie d'évaluation d'Isschat ?",
-    "isschat_response": "Bonjour ! D'après les extraits dont je dispose, il n'y a pas d'information spécifique concernant la stratégie d'évaluation d'ISSCHAT. Je vous suggère de consulter directement la documentation officielle de votre projet ou de vérifier dans Confluence si un document dédié à cette stratégie existe. Si vous avez accès à d'autres sections ou documents, n'hésitez pas à me les partager, je pourrai vous aider à chercher plus précisément.\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
+    "isschat_response": "Bonjour ! D'après les documents dont je dispose, il n'y a pas d'information spécifique concernant la stratégie d'évaluation d'Isschat. Je vous suggère de consulter directement la documentation officielle de votre projet ou de contacter l'équipe en charge pour obtenir des détails précis. Si vous avez d'autres questions sur la configuration ou l'utilisation, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
     "expected_answer": "Doit retrouver la documentation liée à l’évaluation d’Isschat et en faire une synthèse.",
     "evaluation": "rather good"
   },
   {
     "question": "Cite moi un des collaborateurs d'Isschat",
-    "isschat_response": "Je suis désolé, mais je n'ai pas d'informations sur les collaborateurs d'ISSCHAT dans les documents disponibles. Je vous suggère de consulter directement la documentation officielle de votre équipe ou de contacter un responsable pour obtenir ces détails. Si vous avez d'autres questions, n'hésitez pas !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
+    "isschat_response": "Bonjour ! Malheureusement, je n'ai pas d'information concernant les collaborateurs d'ISSCHAT dans les documents disponibles. Je vous suggère de consulter directement la documentation officielle de votre équipe ou de contacter votre responsable pour obtenir ces détails. N'hésitez pas si je peux vous aider sur autre chose !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
     "expected_answer": "Doit nommer un collaborateur connu d’Isschat.",
     "evaluation": "rather good"
   },

--- a/Evaluation/question_dataset.json
+++ b/Evaluation/question_dataset.json
@@ -1,0 +1,92 @@
+[
+  {
+    "question": "Connais-tu Isschat ?",
+    "isschat_response": "Bonjour ! Oui, Isschat est votre assistant virtuel professionnel et convivial, conçu pour vous aider à trouver des informations dans la documentation Confluence. Si vous avez des questions ou besoin d’aide pour naviguer dans les documents, je suis là pour vous accompagner. N’hésitez pas à me demander ce dont vous avez besoin !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
+    "expected_answer": "Éviter les réponses binaires : oui/non. Réponse contextuelle présentant Isschat (objectif, usage, intégration, etc.).",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Parle moi du daily du 35 mai 2018 ?",
+    "isschat_response": "Bonjour ! Malheureusement, je n'ai pas d'informations concernant un \"daily du 35 mai 2018\" dans la documentation disponible. Je vous suggère de vérifier directement dans vos archives Confluence ou de consulter vos notes internes pour cette date spécifique. Si vous avez besoin d'aide pour configurer ou accéder à votre espace Confluence, je suis là pour vous guider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Environment Variables](dummy_doc_3)  \n- [Welcome](dummy_doc_1)",
+    "expected_answer": "Doit détecter que la date est invalide (35 mai n'existe pas) et l’indiquer clairement.",
+    "evaluation": "rather bad"
+  },
+  {
+    "question": "Connais tu Emin Lambropoulos ?",
+    "isschat_response": "Bonjour ! Je n’ai pas d’informations concernant Emin Lambropoulos dans la documentation Confluence à ma disposition. Je vous suggère de vérifier dans d’autres sources internes ou de contacter directement votre réseau professionnel pour en savoir plus. Si vous avez besoin d’aide pour autre chose liée à Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Environment Variables](dummy_doc_3)",
+    "expected_answer": "Doit indiquer ne pas connaître cette personne. Peut mentionner qu’il connaît Nicolas Lambropoulos et Emin Calyaka.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Connais tu Johan Jublanc ?",
+    "isschat_response": "Bonjour ! Je n'ai pas d'informations concernant Johan Jublanc dans la documentation Confluence dont je dispose actuellement. Je vous suggère de vérifier directement dans votre base de données interne ou de consulter vos collègues qui pourraient en savoir plus. Si vous avez d'autres questions sur la configuration ou l'utilisation de Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
+    "expected_answer": "Doit fournir des informations sur les contributions de Johan Jublanc disponibles sur Confluence.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "A quoi sert l'eau ?",
+    "isschat_response": "Bonjour ! Votre question sur l'eau ne concerne pas directement la documentation Confluence dont je dispose. Cependant, pour répondre brièvement, l'eau est essentielle à la vie : elle hydrate, permet les réactions chimiques dans les organismes, et est indispensable à de nombreux processus naturels et industriels. \n\nSi vous avez des questions spécifiques sur la documentation Confluence ou son utilisation, je vous invite à me les poser, je serai ravi de vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Environment Variables](dummy_doc_3)",
+    "expected_answer": "Doit rediriger vers le contexte entreprise ou indiquer que ce n’est pas dans le périmètre d’Isschat.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Sur quelles missions Vincent Fraillon travaille-t-il actuellement ?",
+    "isschat_response": "Bonjour ! Malheureusement, je n’ai pas d’informations concernant les missions actuelles de Vincent Fraillon dans la documentation disponible. Je vous suggère de consulter directement les ressources internes de votre équipe ou de contacter Vincent ou son manager pour obtenir ces détails. Si vous avez d’autres questions sur la configuration ou l’utilisation de Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Welcome](dummy_doc_1)",
+    "expected_answer": "Doit donner des missions actuelles de Vincent Fraillon si disponibles.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Je suis stagiaire chez Isskar, quelles sont mes avantages ?",
+    "isschat_response": "Bonjour ! Malheureusement, je n’ai pas d’informations spécifiques concernant les avantages pour les stagiaires chez Isskar dans la documentation disponible. Je vous suggère de consulter directement votre responsable RH ou votre tuteur de stage pour obtenir ces détails. Si vous avez d’autres questions sur la configuration ou l’utilisation de Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
+    "expected_answer": "Doit demander plus de précisions ou fournir une liste des avantages si disponibles.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Quel est le lien entre Isskar et le nœud Gordien ?",
+    "isschat_response": "Bonjour ! D'après les documents dont je dispose, je n'ai malheureusement pas d'information concernant un lien entre Isskar et le nœud Gordien. Je vous suggère de consulter directement la documentation Confluence ou de poser la question à un expert du domaine concerné pour obtenir des détails précis. Si vous avez d'autres questions ou besoin d'aide sur la configuration ou l'utilisation de Confluence, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
+    "expected_answer": "Doit retrouver la page parlant du nœud Gordien et expliquer le lien.",
+    "evaluation": "rather bad"
+  },
+  {
+    "question": "Qui lead le projet CIBTP ?",
+    "isschat_response": "Bonjour ! D'après les extraits de documents dont je dispose, je n'ai malheureusement pas d'information concernant la personne qui lead le projet CIBTP. Je vous suggère de consulter directement les pages spécifiques du projet dans Confluence ou de contacter votre responsable d'équipe pour obtenir cette information. Si vous avez d'autres questions, je suis là pour vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
+    "expected_answer": "Doit identifier et nommer le ou la responsable du projet CIBTP.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Décris moi le brief qui a été fait pour Adam ?",
+    "isschat_response": "Bonjour ! D'après les documents dont je dispose, je n'ai malheureusement pas d'informations spécifiques concernant un brief fait pour Adam. Je vous suggère de vérifier directement dans la documentation Confluence ou de consulter les notes de réunion associées à ce projet. Si vous avez d'autres questions ou besoin d'aide pour trouver des informations précises, n'hésitez pas à me demander !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Configuration](dummy_doc_2)  \n- [Welcome](dummy_doc_1)",
+    "expected_answer": "Doit refuser l’accès à cette information si elle est confidentielle.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Tell me more about Cedrus project.",
+    "isschat_response": "Bonjour ! Malheureusement, je n'ai pas d'informations spécifiques concernant le projet Cedrus dans les documents disponibles. Je vous suggère de vérifier directement dans votre espace Confluence ou de contacter un collègue qui pourrait avoir accès à ces données. Si vous souhaitez, je peux aussi vous aider à formuler une recherche plus précise dans la documentation. N’hésitez pas à me demander !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
+    "expected_answer": "Doit répondre en français, même si la question est en anglais.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Résume moi les articles de la veille technique 2024-12-16",
+    "isschat_response": "Bonjour ! Malheureusement, je ne dispose pas des articles de la veille technique du 16 décembre 2024 dans les documents accessibles actuellement. Je vous suggère de vérifier directement dans votre espace Confluence ou de consulter la section dédiée aux veilles techniques pour cette date précise. Si vous avez besoin d’aide pour configurer votre connexion Confluence afin d’accéder aux données réelles, je peux vous guider avec plaisir !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
+    "expected_answer": "Doit retrouver la veille technique de cette date et la résumer clairement.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Quelle est la stratégie d'évaluation d'Isschat ?",
+    "isschat_response": "Bonjour ! D'après les extraits dont je dispose, il n'y a pas d'information spécifique concernant la stratégie d'évaluation d'ISSCHAT. Je vous suggère de consulter directement la documentation officielle de votre projet ou de vérifier dans Confluence si un document dédié à cette stratégie existe. Si vous avez accès à d'autres sections ou documents, n'hésitez pas à me les partager, je pourrai vous aider à chercher plus précisément.\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
+    "expected_answer": "Doit retrouver la documentation liée à l’évaluation d’Isschat et en faire une synthèse.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Cite moi un des collaborateurs d'Isschat",
+    "isschat_response": "Je suis désolé, mais je n'ai pas d'informations sur les collaborateurs d'ISSCHAT dans les documents disponibles. Je vous suggère de consulter directement la documentation officielle de votre équipe ou de contacter un responsable pour obtenir ces détails. Si vous avez d'autres questions, n'hésitez pas !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Environment Variables](dummy_doc_3)",
+    "expected_answer": "Doit nommer un collaborateur connu d’Isschat.",
+    "evaluation": "rather good"
+  },
+  {
+    "question": "Cite moi l'autre",
+    "isschat_response": "Bonjour ! Pourriez-vous préciser ce que vous entendez par \"l'autre\" ? Je n'ai pas assez d'informations dans les extraits fournis pour comprendre exactement ce que vous souhaitez. N'hésitez pas à me donner plus de détails, je serai ravi de vous aider !\n\nSources: Voici les 2 sources que j'ai utilisées pour répondre à votre question:  \n- [Welcome](dummy_doc_1)  \n- [Configuration](dummy_doc_2)",
+    "expected_answer": "Doit conserver le contexte de la question précédente (Cite moi un des collaborateurs d'Isschat) et citer un autre collaborateur.",
+    "evaluation": "rather bad"
+  }
+]

--- a/Evaluation/run_evaluation.py
+++ b/Evaluation/run_evaluation.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+Simple runner script for Isschat evaluation
+"""
+
+import sys
+from pathlib import Path
+
+# Add the current directory to Python path
+sys.path.append(str(Path(__file__).parent))
+
+from eval_answer_relevance import main
+
+if __name__ == "__main__":
+    print("🚀 Starting Isschat Evaluation System")
+    print("=" * 50)
+    main()


### PR DESCRIPTION
For the overall evaluation of Isschat, I created a specified directory named evaluation where you can launch the evaluation.

This PR  add the LLM as a judge evaluation on 15 questions in a JSON file.

**More precisely :** 

- A json file (question_dataset.json)
{
      "question": « The question sent to isschat »,
      "isschat_response": « isschat’s response »,
      "expected_answer": « the expected elements of the answer »,
      "evaluation": « evaluation of the llm as a judge : rather good / rather bad »
},

- An LLM evaluation logic that classifies ("rather good" / "rather bad")  Isschat's answers based on the 15 questions.
- The evaluation is then stored in question_dataset.json


